### PR TITLE
Fix function names, misleading use of web.config keys in Startup.Auth.cs

### DIFF
--- a/TodoSPA/App_Start/Startup.Auth.cs
+++ b/TodoSPA/App_Start/Startup.Auth.cs
@@ -14,7 +14,7 @@ namespace TodoSPA
             app.UseWindowsAzureActiveDirectoryBearerAuthentication(
                 new WindowsAzureActiveDirectoryBearerAuthenticationOptions
                 {
-                    Audience = ConfigurationManager.AppSettings["ida:Audience"],
+                    Audience = ConfigurationManager.AppSettings["ida:ClientID"],
                     Tenant = ConfigurationManager.AppSettings["ida:Tenant"]
                 });
         }

--- a/TodoSPA/index.html
+++ b/TodoSPA/index.html
@@ -28,8 +28,8 @@
                     <li ng-class="{ active: isActive('/UserData') }"><a href="#/UserData" ng-show="userInfo.isAuthenticated">User</a></li>
                 </ul>
                 <ul class="nav navbar-nav navbar-right">
-                    <li><button class="btn btn-link" ng-show="userInfo.isAuthenticated" ng-click="Logout()">Logout</button></li>
-                    <li><button class="btn btn-link" ng-hide=" userInfo.isAuthenticated" ng-click="Login()">Login</button></li>
+                    <li><button class="btn btn-link" ng-show="userInfo.isAuthenticated" ng-click="logout()">Logout</button></li>
+                    <li><button class="btn btn-link" ng-hide=" userInfo.isAuthenticated" ng-click="login()">Login</button></li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
Two fixes applied:
1- Fix login, logout JS function names as they do not match function names in homeCtrl.js
2- Use "ida:ClientID" value as the audience value, comments in web.config for those keys are misleading.
