### PR TITLE
Fixed Git URL for sample repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Every Azure subscription has an associated Azure Active Directory tenant.  If yo
 ### Step 1:  Clone or download this repository
 
 From your shell or command line:
-`git clone https://github.com/Azure-Samples/SinglePageApp-DotNet.git`
+`git clone https://github.com/Azure-Samples/active-directory-angularjs-singlepageapp.git`
 
 ### Step 2:  Register the sample with your Azure Active Directory tenant
 


### PR DESCRIPTION
URL was still pointing at old samples structure folder
