### PR TITLE
Replaced obsolete code.

### DIFF
--- a/TodoSPA/App_Start/Startup.Auth.cs
+++ b/TodoSPA/App_Start/Startup.Auth.cs
@@ -14,8 +14,11 @@ namespace TodoSPA
             app.UseWindowsAzureActiveDirectoryBearerAuthentication(
                 new WindowsAzureActiveDirectoryBearerAuthenticationOptions
                 {
-                    Audience = ConfigurationManager.AppSettings["ida:Audience"],
-                    Tenant = ConfigurationManager.AppSettings["ida:Tenant"]
+                    Tenant = ConfigurationManager.AppSettings["ida:Tenant"],
+                    TokenValidationParameters = new System.IdentityModel.Tokens.TokenValidationParameters
+                    {
+                        ValidAudience = ConfigurationManager.AppSettings["ida:Audience"],
+                    }
                 });
         }
 


### PR DESCRIPTION
The current code builds successfully but warns that `WindowsAzureActiveDirectoryBearerAuthenticationOptions.Audience` is deprecated and obsolete (CS0618). This is confirmed when the application is launched, immediately throwing an unhandled `HttpRequestException`.

The error message suggests using `TokenValidationParameters.ValidAudience`, as done here, which results in a working sample when the relevant fields are filled in.